### PR TITLE
Fixed Typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ bot.on("ready" => {
 });
 
 // Detects when someone votes for your bot
-bot.on("botVote", (vote) => console.log(vote));
+client.on("botVote", (vote) => console.log(vote));
 
 // Login your bot
 bot.login(token);


### PR DESCRIPTION
bot.on("botVote", (vote) => console.log(vote));   Note: In the example bot is the discord client and not blist so it should be client instead of bot

client.on("botVote", (vote) => console.log(vote));